### PR TITLE
FIX add dependency on com.intellij.modules.platform

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
     </change-notes>
 
     <idea-version since-build="181"/>
+	<depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
This will fix Plugin Error: Plugin "Git extended update-index" defines no module dependencies (supported only in IntelliJ IDEA).