### PR TITLE
fix: update IntelliJ platform to 2024.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 }
 
 intellijPlatform {
+    buildSearchableOptions = true
     pluginConfiguration {
         name = "Git extended update-index"
         ideaVersion {
@@ -37,7 +38,7 @@ intellijPlatform {
 
 dependencies {
     intellijPlatform {
-        create("IC", "2022.3")
+        create(type = "IC", version = "2024.1", useInstaller = false)
         bundledPlugin("Git4Idea")
 
         pluginVerifier()

--- a/src/main/kotlin/com/github/monosoul/git/updateindex/extended/ExtendedUpdateIndexAction.kt
+++ b/src/main/kotlin/com/github/monosoul/git/updateindex/extended/ExtendedUpdateIndexAction.kt
@@ -6,6 +6,7 @@ import com.github.monosoul.git.updateindex.extended.ExtendedUpdateIndexCommand.N
 import com.github.monosoul.git.updateindex.extended.ExtendedUpdateIndexCommand.SKIP_WORKTREE
 import com.github.monosoul.git.updateindex.extended.support.CommandInvoker
 import com.github.monosoul.git.updateindex.extended.support.PresentationUpdater
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.diagnostic.debug
@@ -18,6 +19,8 @@ import com.intellij.openapi.vfs.VirtualFile
 sealed class ExtendedUpdateIndexAction(private val command: ExtendedUpdateIndexCommand) : DumbAwareAction() {
 
     private val logger = thisLogger()
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(event: AnActionEvent) {
         event.run {

--- a/src/main/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/ToggleSkippedWorktreeAction.kt
+++ b/src/main/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/ToggleSkippedWorktreeAction.kt
@@ -3,6 +3,7 @@ package com.github.monosoul.git.updateindex.extended.changes.view
 import com.github.monosoul.git.updateindex.extended.changes.view.Constants.PROPERTY
 import com.github.monosoul.git.updateindex.extended.support.PresentationUpdater
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.ToggleAction
@@ -14,6 +15,8 @@ import com.intellij.openapi.vcs.changes.ChangesViewManager
 class ToggleSkippedWorktreeAction : ToggleAction() {
 
     private val logger = logger<ToggleSkippedWorktreeAction>()
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(event: AnActionEvent) {
         super.update(event)

--- a/src/test/kotlin/com/github/monosoul/git/updateindex/extended/UpdateIndexLineHandlerFactoryTest.kt
+++ b/src/test/kotlin/com/github/monosoul/git/updateindex/extended/UpdateIndexLineHandlerFactoryTest.kt
@@ -74,6 +74,7 @@ internal class UpdateIndexLineHandlerFactoryTest {
         every { gitExecutableManager.tryGetVersion(any()) } returns CAN_NOT_OVERRIDE_GIT_CONFIG_FOR_COMMAND
         every { gitExecutableManager.getExecutable(project) } returns gitExecutable
         every { gitExecutable.exePath } returns exePath
+        every { gitExecutable.isLocal } returns true
     }
 
     @AfterEach

--- a/src/test/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/GetSkippedWorktreeFilesTaskTest.kt
+++ b/src/test/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/GetSkippedWorktreeFilesTaskTest.kt
@@ -157,7 +157,7 @@ internal class GetSkippedWorktreeFilesTaskTest {
         }
 
         expectThat(captor.captured) {
-            get { printableCommandLine() } isEqualTo "git ls-files -v"
+            get { printableCommandLine() } isEqualTo "\"\" ls-files -v"
         }
     }
 

--- a/src/test/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/SkippedWorktreeChangesViewModifierTest.kt
+++ b/src/test/kotlin/com/github/monosoul/git/updateindex/extended/changes/view/SkippedWorktreeChangesViewModifierTest.kt
@@ -11,10 +11,12 @@ import com.intellij.mock.MockApplication
 import com.intellij.mock.MockLocalFileSystem
 import com.intellij.mock.MockProject
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.AsyncExecutionService
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Disposer.dispose
 import com.intellij.openapi.vcs.FilePath
 import com.intellij.openapi.vcs.LocalFilePath
+import com.intellij.openapi.vcs.actions.VcsContextFactory
 import com.intellij.openapi.vcs.changes.ui.ChangesBrowserNode
 import com.intellij.openapi.vcs.changes.ui.ChangesViewModelBuilder
 import com.intellij.openapi.vcs.changes.ui.NoneChangesGroupingFactory
@@ -22,6 +24,7 @@ import com.intellij.openapi.vcs.changes.ui.TreeModelBuilder
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.peer.impl.VcsContextFactoryImpl
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -53,6 +56,10 @@ internal class SkippedWorktreeChangesViewModifierTest {
     private lateinit var project: MockProject
     private lateinit var propertiesComponent: AppPropertyService
     private lateinit var localFileSystem: MockLocalFileSystem
+    private lateinit var vcsContextFactory: VcsContextFactory
+
+    @MockK(relaxed = true)
+    private lateinit var asyncExecutionService: AsyncExecutionService
 
     @MockK(relaxUnitFun = true)
     private lateinit var progressManager: ProgressManager
@@ -81,6 +88,11 @@ internal class SkippedWorktreeChangesViewModifierTest {
 
         application.registerService(virtualFileManager, parent)
         every { virtualFileManager.getFileSystem(any()) } returns localFileSystem
+
+        vcsContextFactory = VcsContextFactoryImpl()
+        application.registerService(vcsContextFactory, parent)
+
+        application.registerService(asyncExecutionService, parent)
 
         modifier = SkippedWorktreeChangesViewModifier(project)
     }


### PR DESCRIPTION
Bumps IntelliJ platform to 2024.1, fixing deprecated API usages along the way

Fixes #59 